### PR TITLE
Improve parser internals a bit, update parser test cases

### DIFF
--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
@@ -59,7 +59,7 @@ object JsonParser {
 
     in Regex("\\d"), '-' -> {
       val num = run loop@{ from.tail.fold(from.head.toString()) { acc, c ->
-        if(c in Regex("[.eE]") && acc.contains(c, true))
+        if(c == '-' || c in Regex("[.eE]") && acc.contains(c, true))
           throw JsonParseError("Unexpected $c while parsing number")
         if(c !in Regex("[.eE\\d]"))
           return@loop acc

--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
@@ -20,6 +20,8 @@ object JsonParser {
     class Int(text: kotlin.String) : Token(text)
     class Float(text: kotlin.String) : Token(text)
     class String(text: kotlin.String) : Token(text)
+
+    override fun toString() = text
   }
 
   /** Thrown by [parse] when a parsing error occurs. */

--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
@@ -51,9 +51,12 @@ object JsonParser {
     ':' -> lex(from.tail, tokens + Token.Colon)
 
     '"' -> {
-      var last = '\u0000'
-      val tail = from.tail.takeWhile { val t = last == '\\' || it != '"'; last = it; t }
-      lex(from.drop(tail.length + 2), tokens + Token.String(tail))
+      val str = run loop@{ from.tail.fold("") { acc, c ->
+        if(c == '"' && !acc.endsWith('\\')) return@loop acc
+        acc + c
+      }}
+
+      lex(from.drop(str.length + 2), tokens + Token.String(str))
     }
 
     in Regex("\\d"), '-' -> {

--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
@@ -20,8 +20,6 @@ object JsonParser {
     class Int(text: kotlin.String) : Token(text)
     class Float(text: kotlin.String) : Token(text)
     class String(text: kotlin.String) : Token(text)
-
-    object Noop : Token("")
   }
 
   /** Thrown by [parse] when a parsing error occurs. */
@@ -35,13 +33,13 @@ object JsonParser {
    */
   fun parse(from: String): Json {
     val (parsed, tail) = parse(lex(from))
-    if (tail.any { it != Token.Noop })
+    if(tail.isNotEmpty())
       throw JsonParseError("Input string contains unexpected tokens before EOF")
     return parsed
   }
 
   private tailrec fun lex(from: String, tokens: List<Token> = emptyList()): List<Token> = when (from.head) {
-    null -> tokens + Token.Noop
+    null -> tokens
     in Regex("\\s") -> lex(from.trim(), tokens)
     '{' -> lex(from.tail, tokens + Token.ObjectBegin)
     '}' -> lex(from.tail, tokens + Token.ObjectEnd)
@@ -119,7 +117,6 @@ object JsonParser {
     Token.True -> JsonBoolean(true) to tokens.tail
     Token.False -> JsonBoolean(false) to tokens.tail
     Token.Null -> JsonNull to tokens.tail
-    Token.Noop -> parse(tokens.tail)
 
     is Token.Int -> JsonInt(tokens.head!!.text.toInt()) to tokens.tail
     is Token.Float -> JsonFloat(tokens.head!!.text.toFloat()) to tokens.tail

--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonParser.kt
@@ -78,7 +78,7 @@ object JsonParser {
     }
   }
 
-  private tailrec fun parse(tokens: List<Token>): Pair<Json, List<Token>> = when (tokens.head) {
+  private fun parse(tokens: List<Token>): Pair<Json, List<Token>> = when (tokens.head) {
     Token.ObjectBegin -> {
       var tail = tokens.tail
       var pairs: List<Pair<String, Json>> = emptyList()

--- a/src/test/kotlin/com/tripl3dogdare/havenjson/ParserTest.kt
+++ b/src/test/kotlin/com/tripl3dogdare/havenjson/ParserTest.kt
@@ -2,6 +2,7 @@ package com.tripl3dogdare.havenjson
 
 import io.kotlintest.matchers.maps.shouldContainKey
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 import java.io.File
 
@@ -13,6 +14,44 @@ class ParserTest : WordSpec() {
           results.shouldContainKey(file.name)
           Json.parse(file.readText()) shouldBe results[file.name]
         }
+
+      "throw on invalid numbers" {
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "number": 42-73 }""") }
+          .also { it.message shouldBe "Unexpected - while parsing number" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "number": 42.7.3 }""") }
+          .also { it.message shouldBe "Unexpected . while parsing number" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "number": 42e7e3 }""") }
+          .also { it.message shouldBe "Unexpected e while parsing number" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "number": 42E7E3 }""") }
+          .also { it.message shouldBe "Unexpected E while parsing number" }
+      }
+
+      "throw on invalid objects" {
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "test": "Hello, world!" """) }
+          .also { it.message shouldBe "Unexpected EOF when parsing object" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "test", "Hello, world!" }""") }
+          .also { it.message shouldBe "Objects must follow the structure {\"key1\":value1,\"key2\":value2}" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""{ "test": "Hello, world!": "test2": "Hello, world!" }""") }
+          .also { it.message shouldBe "Objects must follow the structure {\"key1\":value1,\"key2\":value2}" }
+      }
+
+      "throw on invalid arrays" {
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""[ "test", "test" """) }
+          .also { it.message shouldBe "Unexpected EOF when parsing array" }
+      }
+
+      "throw on unexpected tokens" {
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""]""") }
+          .also { it.message shouldBe "Unexpected ] when parsing JSON" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""}""") }
+          .also { it.message shouldBe "Unexpected } when parsing JSON" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse(""",""") }
+          .also { it.message shouldBe "Unexpected , when parsing JSON" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse(""":""") }
+          .also { it.message shouldBe "Unexpected : when parsing JSON" }
+        shouldThrow<JsonParser.JsonParseError> { Json.parse("""[] 73""") }
+          .also { it.message shouldBe "Input string contains unexpected tokens before EOF" }
+      }
     }
   }
 

--- a/src/test/kotlin/com/tripl3dogdare/havenjson/ParserTest.kt
+++ b/src/test/kotlin/com/tripl3dogdare/havenjson/ParserTest.kt
@@ -8,7 +8,7 @@ import java.io.File
 class ParserTest : WordSpec() {
   init {
     "JsonValue#parse" should {
-      for(file in File("./test_files/").walkTopDown().filter { it.isFile })
+      for(file in File("./src/test/test_files/").walkTopDown().filter { it.isFile })
         "correctly parse ${file.name}" {
           results.shouldContainKey(file.name)
           Json.parse(file.readText()) shouldBe results[file.name]


### PR DESCRIPTION
The parser implementation before this point was almost a direct translation from the parser in my previous project, [scjson](/tripl3dogdare/scjson), nearly a year ago. As such, it has some legacy warts and lumps. This PR attempts to smooth out some of those issues.

This PR makes no breaking changes to the front-facing API.

**DONE**
- The path to the test files used in the parser's test cases was incorrect for the default configuration, so I've updated it to work without additional setup.
- Strings and numbers were being lexed with an over-complicated system based on local mutation; I've replaced both with `fold`-based implementations that are much cleaner and easier to understand.
- The `Noop` token type was essentially useless, and was only used to mark the end of the token stream - I've removed it in favor of the `isNotEmpty` method.
- With the `Noop` token removed, the only tail-recursive call in `JsonParser#parse` was also removed, and so I've removed the `tailrec` annotation from the method.
- I've added test cases for the various error messages that can arise from the parser, to ensure that it reacts as expected in erroneous circumstances.

**PLANNED FOR FUTURE PRS**
- Add source position tracking to tokens/error messages
- Remove local mutation from array/object parsing if possible
- Continue improving test cases