### PR TITLE
Add automatic serializer functions to JsonSchema classes (#12)

### DIFF
--- a/src/main/kotlin/com/tripl3dogdare/havenjson/JsonSchema.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/JsonSchema.kt
@@ -9,6 +9,19 @@ import kotlin.reflect.jvm.*
  * Inheriting from this marks a class as a valid target for [JsonValue.Companion.deserialize].
  */
 interface JsonSchema {
+  @Suppress("unchecked_cast")
+  fun toJson(nameConverter: NameConverter = AS_WRITTEN):JsonObject {
+    val constructor = this::class.primaryConstructor
+      ?: throw NullPointerException("Cannot serialize constructorless class to JSON.")
+
+    val out = constructor.parameters.map { param ->
+      val prop = this::class.declaredMemberProperties.first { it.name == param.name } as KProperty1<JsonSchema, Any?>
+      nameConverter(param.name!!) to Json(prop.get(this))
+    }
+
+    return JsonObject(out.toMap())
+  }
+
   companion object {
     /** Name converter function that leaves names as-is. */
     val AS_WRITTEN: NameConverter = { it }

--- a/src/test/kotlin/com/tripl3dogdare/havenjson/SerializerTest.kt
+++ b/src/test/kotlin/com/tripl3dogdare/havenjson/SerializerTest.kt
@@ -1,0 +1,73 @@
+package com.tripl3dogdare.havenjson
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+class SerializerTest : WordSpec({
+  "JsonSchema#toJson" should {
+    "properly serialize basic types" {
+      BasicTypes(100, 100f, "test", false, null).toJson() shouldBe
+        Json("int" to 100, "float" to 100f, "string" to "test", "bool" to false, "nil" to null)
+    }
+
+    "properly serialize lists" {
+      Lists(listOf(100),
+            listOf(100f),
+            listOf("test"),
+            listOf(true, false),
+            listOf(null))
+      .toJson() shouldBe
+        Json("int" to listOf(100),
+             "float" to listOf(100f),
+             "string" to listOf("test"),
+             "bool" to listOf(true, false),
+             "nil" to listOf(null))
+    }
+
+    "properly serialize JSON types" {
+      JsonTypes(JsonInt(100),
+                JsonFloat(100f),
+                JsonString("test"),
+                JsonBoolean(false),
+                JsonNull,
+                JsonArray(listOf(JsonBoolean(true), JsonBoolean(false))),
+                JsonObject(mapOf("greeting" to JsonString("Hello"),
+                                 "target" to JsonString("world"))))
+      .toJson() shouldBe
+        Json("int" to 100,
+             "float" to 100f,
+             "string" to "test",
+             "bool" to false,
+             "nil" to null,
+             "arr" to listOf(true, false),
+             "obj" to mapOf("greeting" to "Hello",
+                            "target" to "world"))
+    }
+  }
+}) {
+  data class BasicTypes(
+    val int:Int,
+    val float:Float,
+    val string:String,
+    val bool:Boolean,
+    val nil:Nothing?
+  ) : JsonSchema
+
+  data class Lists(
+    val int:List<Int>,
+    val float:List<Float>,
+    val string:List<String>,
+    val bool:List<Boolean>,
+    val nil:List<Nothing?>
+  ) : JsonSchema
+
+  data class JsonTypes(
+    val int:JsonInt,
+    val float:JsonFloat,
+    val string:JsonString,
+    val bool:JsonBoolean,
+    val nil:JsonNull,
+    val arr:JsonArray,
+    val obj:JsonObject
+  ) : JsonSchema
+}


### PR DESCRIPTION
This PR aims to add a `toJson` function to `JsonSchema` that will allow for easy re-serialization of JSON data from Kotlin objects. This will close issue #12 when merged.

## Current state as of October 4, 2018

`JsonSchema.toJson` is implemented in a rudimentary form, which can successfully serialize objects consisting only of primitive types, lists, maps, and `JsonValue`s. Anything else will be serialized to a `JsonString` by calling it's `toString` method. Additionally, a `NameConverter` can be passed to the method to modify the names of the resulting JSON fields. The method returns a `Json` object, which can then be serialized to a string with `mkString`.

## Todo
- [x] Serialize basic types
- [ ] Custom serializer functions
- [ ] Warn/error on defaulting to `toString` for serialization?
- [ ] Respect `@JsonProperty` annotations
- [ ] Look into methods for automatically reversing deserializer functions?