### PR TITLE
Rewrite String.jsonEscape() and String.jsonUnescape().

### DIFF
--- a/src/main/kotlin/com/tripl3dogdare/havenjson/Utils.kt
+++ b/src/main/kotlin/com/tripl3dogdare/havenjson/Utils.kt
@@ -1,33 +1,31 @@
 package com.tripl3dogdare.havenjson
 
-internal tailrec fun String.jsonEscape(acc:String=""):String {
-  if(this.isEmpty()) return acc
-  return when(this[0]) {
-    '\"' -> tail.jsonEscape("$acc\\\"")
-    '\\' -> tail.jsonEscape("$acc\\\\")
-    '\n' -> tail.jsonEscape("$acc\\n")
-    '\b' -> tail.jsonEscape("$acc\\b")
-    '\r' -> tail.jsonEscape("$acc\\r")
-    '\t' -> tail.jsonEscape("$acc\\t")
-    '\u000C' -> tail.jsonEscape("$acc\\f")
-    else -> tail.jsonEscape(acc+this[0])
+internal fun String.jsonEscape() = fold("") { acc, c ->
+  acc + when (c) {
+    '\"' -> """\""""
+    '\\' -> """\\"""
+    '\n' -> """\n"""
+    '\b' -> """\b"""
+    '\r' -> """\r"""
+    '\t' -> """\t"""
+    '\u000C' -> """\f"""
+    else -> c
   }
 }
 
-internal tailrec fun String.jsonUnescape(acc:String=""):String {
-  if(this.isEmpty()) return acc
-  return if(this[0] == '\\') when(this[1]) {
-    '"' -> drop(2).jsonUnescape("$acc\"")
-    '\\' -> drop(2).jsonUnescape("$acc\\")
-    'n' -> drop(2).jsonUnescape("$acc\n")
-    'b' -> drop(2).jsonUnescape("$acc\b")
-    'r' -> drop(2).jsonUnescape("$acc\r")
-    't' -> drop(2).jsonUnescape("$acc\t")
-    'f' -> drop(2).jsonUnescape("$acc\u000c")
-    'u' -> drop(6).jsonUnescape(acc+this.drop(2).take(4).toInt(16).toChar())
-    else -> drop(2).jsonUnescape(acc+this[1])
-  } else tail.jsonUnescape(acc+this[0])
-}
+internal fun String.jsonUnescape() = replaceAll(mapOf(
+  """\"""" to "\"",
+  """\\""" to "\\",
+  """\n""" to "\n",
+  """\b""" to "\b",
+  """\r""" to "\r",
+  """\t""" to "\t",
+  """\f""" to "\u000c"))
+  .replace(Regex("""\\u([0-9A-Fa-f]{4})""")) {
+    it.groupValues[1].toInt(16).toChar().toString()
+  }
+  // Anything else - return as is (without the '\').
+  .replace(Regex("""\\([^"\\nbrtfu])""")) { it.groupValues[1] }
 
 internal fun String.indent(spaces:Int=2) =
   split("\n").map { " ".repeat(spaces)+it }.joinToString("\n")
@@ -38,3 +36,8 @@ internal val <T, C : Collection<T>> C.head get():T? = elementAtOrNull(0)
 internal val <T, C : Collection<T>> C.tail get():List<T> = drop(1)
 internal operator fun Regex.contains(text:Char):Boolean = contains(text.toString())
 internal operator fun Regex.contains(text:CharSequence):Boolean = this.matches(text)
+
+private fun String.replaceAll(mapping: Map<String, String>) =
+  mapping.entries.fold(this) { acc, entry ->
+    acc.replace(entry.key, entry.value)
+  }


### PR DESCRIPTION
jsonEscape() was rewritten in a functional programming approach, using the fold() operation. This gets rid of the need to check isEmpty(), reference this[0] and recursively call the method, making it considerably more readable and easier to maintain.

jsonUnescape() was rewritten to improve readability and maintainability as well by using replace() and the convenience method replaceAll().

All tests pass.